### PR TITLE
Fix docs slugs

### DIFF
--- a/apps/frontpage/app/docs/[[...slug]]/layout.tsx
+++ b/apps/frontpage/app/docs/[[...slug]]/layout.tsx
@@ -1,14 +1,13 @@
 import type { Metadata } from 'next';
 import { Header, Footer, Container } from '@repo/ui';
 import Image from 'next/image';
-import { fetchGithubCount } from '@repo/utils';
+import { fetchGithubCount, latestVersion } from '@repo/utils';
 import { Sidebar } from '../../../components/docs/sidebar/sidebar';
 import { TableOfContent } from '../../../components/docs/table-of-content';
 import { NavDocs } from '../../../components/docs/sidebar/docs-nav';
 import { generateDocsTree } from '../../../lib/get-tree';
 import { DocsProvider } from '../provider';
 import { getVersion } from '../../../lib/get-version';
-import { slugHasVersion } from '../../../lib/slug-has-version';
 import { getPageData } from '../../../lib/get-page';
 import { Submenu } from '../../../components/docs/submenu';
 
@@ -29,11 +28,12 @@ export default async function Layout({
   const activeVersion = getVersion(slug);
   const path = `content/docs/${activeVersion.id}`;
   const tree = generateDocsTree(path);
-  const hasVersion = slugHasVersion(slug);
-  const newSlug = slug ? [...slug] : [];
-  if (!hasVersion) newSlug.unshift(activeVersion.id);
+  const isLatest = activeVersion.id === latestVersion.id;
+  const slugToFetch = slug ? [...slug] : [];
+  if (!isLatest) slugToFetch.shift();
+  slugToFetch.unshift(activeVersion.id);
 
-  const page = await getPageData(newSlug, activeVersion);
+  const page = await getPageData(slugToFetch, activeVersion);
 
   return (
     <DocsProvider>

--- a/apps/frontpage/components/docs/sidebar/version-selector.tsx
+++ b/apps/frontpage/components/docs/sidebar/version-selector.tsx
@@ -4,7 +4,7 @@ import type { FC } from 'react';
 import { ChevronSmallDownIcon } from '@storybook/icons';
 import Link from 'next/link';
 import type { DocsVersion } from '@repo/utils';
-import { docsVersions } from '@repo/utils';
+import { docsVersions, latestVersion } from '@repo/utils';
 import { usePathname } from 'next/navigation';
 import {
   DropdownMenu,
@@ -23,21 +23,24 @@ export const VersionSelector: FC<VersionSelectorProps> = ({
   const pathname = usePathname();
   const segments = pathname.slice(1).split('/');
 
-  const getLink = (version: string) => {
-    const isFirstVersion = version === docsVersions[0]?.id;
-    const activeVersionIndex = segments.findIndex(
-      (segment) => segment === activeVersion.id,
-    );
-    const isVersionInUrl = activeVersionIndex !== -1;
+  const onLatestVersion = activeVersion.id === latestVersion.id;
+
+  const getLink = (version: DocsVersion) => {
+    const toLatestVersion = version.id === latestVersion.id;
 
     const newSegments = [...segments];
     let newHref = `/${newSegments.join('/')}`;
 
-    if (!isVersionInUrl && !isFirstVersion)
-      newHref = newHref.replace('/docs', `/docs/${version}`);
-    if (isVersionInUrl) newHref = newHref.replace(activeVersion.id, version);
-    if (isVersionInUrl && isFirstVersion)
-      newHref = newHref.replace(`/${version}`, '');
+    if (onLatestVersion && !toLatestVersion) {
+      newHref = newHref.replace('/docs', `/docs/${version.inSlug || version.id}`);
+    } else if (!onLatestVersion && toLatestVersion) {
+      newHref = newHref.replace(`/docs/${activeVersion.inSlug || activeVersion.id}`, '/docs');
+    } else {
+      newHref = newHref.replace(
+        `/docs/${activeVersion.inSlug || activeVersion.id}`,
+        `/docs/${version.inSlug || version.id}`
+      );
+    }
 
     return newHref;
   };
@@ -53,7 +56,7 @@ export const VersionSelector: FC<VersionSelectorProps> = ({
       <DropdownMenuContent className="ui-min-w-[12.5rem]">
         {docsVersions.map((version) => (
           <DropdownMenuItem asChild key={version.id}>
-            <Link href={getLink(version.id)}>{version.label}</Link>
+            <Link href={getLink(version)}>{version.label}</Link>
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>

--- a/apps/frontpage/lib/get-version.ts
+++ b/apps/frontpage/lib/get-version.ts
@@ -6,7 +6,12 @@ export const getVersion = (slug: string[] | undefined): DocsVersion => {
   const versionFromUrl =
     slug &&
     slug.length >= 1 &&
-    docsVersions.find((version) => slug[0] === version.id);
+    (
+      // Exact version match, e.g. `8.2`
+      docsVersions.find((version) => slug[0] === version.id)
+      // Major version match, e.g. `8` for `8.1`
+      || docsVersions.find((version) => slug[0] === version.id.split('.')[0])
+    );
   if (versionFromUrl) activeVersion = versionFromUrl;
 
   return activeVersion;

--- a/apps/frontpage/lib/slug-has-version.ts
+++ b/apps/frontpage/lib/slug-has-version.ts
@@ -1,9 +1,0 @@
-import { docsVersions } from '@repo/utils';
-
-export const slugHasVersion = (slug: string[] | undefined): boolean => {
-  if (slug === undefined) return false;
-
-  return (
-    slug.length >= 1 && docsVersions.some((version) => slug[0] === version.id)
-  );
-};

--- a/packages/utils/src/docs-versions.tsx
+++ b/packages/utils/src/docs-versions.tsx
@@ -1,21 +1,31 @@
 export interface DocsVersion {
-  /** Used for visual display, e.g. the docs sidebar */
-  label: string;
-  /** Used for routes */
+  /** For fetching content */
   id: string;
+  /** For visual display, e.g. the docs sidebar */
+  label: string;
+  /** For routes */
+  inSlug?: string;
+  preRelease?: boolean;
+  /** The rest of these define the method used to fetch content */
   branch?: string;
   commit?: string;
   tag?: string;
-  preRelease?: boolean;
 }
 
 /**
- * ********************************************
- * ** List of versions of the documentation  **
- * ********************************************
+ * All published versions of the docs.
+ * 
+ * This list relies on some conventions:
+ * 
+ * 1. The latest version must always be first.
+ * 2. The `label` should be... TODO
+ * 3. The `id` must be unique and should be of the form `major.minor` for clarity.
+ * 4. For the pre-release version (there should only be one), `preRelease: true` must be set.
+ * 5. The `inSlug` property (set to the major version) must be defined for:
+ *    - Non-latest non-pre-release versions (e.g. 7.6, 6.5)
+ *    - Pre-release major versions (e.g. 9.0, when in alpha/beta/RC)
+ * 6. Either a `branch`, `commit`, or `tag` must be provided for fetching content.
  **/
-
-/** Latest version must ALWAYS be first */
 export const docsVersions: DocsVersion[] = [
   {
     label: '8.1 (latest)',
@@ -31,11 +41,13 @@ export const docsVersions: DocsVersion[] = [
   {
     label: '7.6',
     id: '7.6',
+    inSlug: '7',
     branch: 'charles-transform-docs-1',
   },
   {
     label: '6.5',
     id: '6.5',
+    inSlug: '6',
     branch: 'charles-transform-docs-1',
   },
 ];


### PR DESCRIPTION
Numerous fixes completing work in #60
- Add `inSlug` property to docsVersions - And thoroughly explain how to use that file
- Refactor slug generate to use `inSlug`
- Simplify page and layout content-fetching logic
- Update VersionSelector to use `inSlug`