### PR TITLE
Fix docs sidebar

### DIFF
--- a/apps/frontpage/app/docs/[[...slug]]/layout.tsx
+++ b/apps/frontpage/app/docs/[[...slug]]/layout.tsx
@@ -9,14 +9,13 @@ import {
 } from '@repo/ui';
 import Image from 'next/image';
 import { TreeProps, fetchGithubCount, latestVersion } from '@repo/utils';
-import { Sidebar } from '../../components/docs/sidebar/sidebar';
-import { TableOfContent } from '../../components/docs/table-of-content';
-import { NavDocs } from '../../components/docs/sidebar/docs-nav';
-import { generateDocsTree } from '../../lib/get-tree';
-import { DocsProvider } from './provider';
-import { getVersion } from '../../lib/get-version';
-import { getPageData } from '../../lib/get-page';
-import { Submenu } from '../../components/docs/submenu';
+import { Sidebar } from '../../../components/docs/sidebar/sidebar';
+import { TableOfContent } from '../../../components/docs/table-of-content';
+import { NavDocs } from '../../../components/docs/sidebar/docs-nav';
+import { generateDocsTree } from '../../../lib/get-tree';
+import { DocsProvider } from '../provider';
+import { getVersion } from '../../../lib/get-version';
+import { Submenu } from '../../../components/docs/submenu';
 
 interface PageProps {
   children: React.ReactNode;
@@ -78,16 +77,16 @@ export default async function Layout({
   children,
   params: { slug },
 }: PageProps) {
+  console.log('docs layout, slug', slug);
   const { number: githubCount } = await fetchGithubCount();
   const activeVersion = getVersion(slug);
+  console.log('docs layout, activeVersion', JSON.stringify(activeVersion, null, 2));
   const path = `content/docs/${activeVersion.id}`;
   const tree = generateDocsTree(path);
   const isLatest = activeVersion.id === latestVersion.id;
   const slugToFetch = slug ? [...slug] : [];
   if (!isLatest) slugToFetch.shift();
   slugToFetch.unshift(activeVersion.id);
-
-  const page = await getPageData(slugToFetch, activeVersion);
 
   return (
     <DocsProvider>


### PR DESCRIPTION
- Move docs layout back under catch-all route - Gains access to `params`, which is needed for the sidebar - But loses the scroll position on navigation, which is why it was [moved up a level in the first place](https://github.com/storybookjs/web/pull/98)
- Fix link generation in sidebar