### PR TITLE
Update latest docs version to fetch from `main`

### DIFF
--- a/apps/frontpage/scripts/get-local-docs.ts
+++ b/apps/frontpage/scripts/get-local-docs.ts
@@ -21,7 +21,9 @@ async function clean(): Promise<void> {
 
 async function fetchAndExtract(version: DocsVersion): Promise<void> {
   // eslint-disable-next-line no-console -- Showing off console.log
-  console.log(`  ♠︎ Fetching docs for ${version.id}...`);
+  console.log(
+    `  ♠︎ Fetching docs for ${version.id} from ${version.branch || version.tag || version.commit}...`,
+  );
 
   let url: string | null = null;
   if (version.branch)

--- a/packages/utils/src/docs-versions.tsx
+++ b/packages/utils/src/docs-versions.tsx
@@ -30,12 +30,12 @@ export const docsVersions: DocsVersion[] = [
   {
     label: 'Version 8.1',
     id: '8.1',
-    branch: 'charles-transform-docs-next',
+    branch: 'main',
   },
   // {
   //   label: '8.2 (beta)',
   //   id: '8.2',
-  //   branch: 'charles-transform-docs-next',
+  //   branch: 'next',
   //   preRelease: true,
   // },
   {


### PR DESCRIPTION
- Add pre-release version to fetch from `next` - Still commented out/
- Log which branch/tag/commit we're fetching from