### PR TITLE
Prevent broken addon icons from rendering

### DIFF
--- a/apps/addon-catalog/components/addon/addon-hero.tsx
+++ b/apps/addon-catalog/components/addon/addon-hero.tsx
@@ -28,9 +28,10 @@ export function AddonHero({ addon }: { addon: Addon }) {
     <div className="mb-12 flex justify-between border-b border-zinc-300 pb-12 dark:border-b-slate-700">
       <div className="flex flex-col gap-8 md:flex-row">
         {addon.icon && (
-          <div className="relative h-20 w-20">
-            <Image src={addon.icon} alt={addon.displayName || ''} fill={true} />
-          </div>
+          <div
+            style={{ backgroundImage: `url('${addon.icon}')` }}
+            className="h-20 w-20 bg-contain bg-center bg-no-repeat"
+          />
         )}
         <div className="flex flex-col items-start">
           <div className="flex items-center gap-2">

--- a/apps/addon-catalog/components/preview.tsx
+++ b/apps/addon-catalog/components/preview.tsx
@@ -35,7 +35,10 @@ export const Preview = ({ element, orientation, type }: PreviewProps) => {
         {!isRecipe && (
           <div className="relative flex h-16 w-16 flex-shrink-0 items-center justify-center">
             {element.icon ? (
-              <img src={element.icon} />
+              <div
+                style={{ backgroundImage: `url('${element.icon}')` }}
+                className="h-16 w-16 bg-contain bg-center bg-no-repeat"
+              />
             ) : (
               <div className="flex h-full w-full items-center justify-center rounded-md bg-zinc-50 dark:bg-slate-800">
                 <StorybookIcon className="h-10 w-10 text-[#FF4785]" />


### PR DESCRIPTION
- By using icon property as CSS `background-image` instead of `<img src />`