### PR TITLE
Move redirects to middleware + Fix Plausible

### DIFF
--- a/apps/frontpage/app/layout.tsx
+++ b/apps/frontpage/app/layout.tsx
@@ -44,14 +44,6 @@ export default function RootLayout({
 }): JSX.Element {
   return (
     <html lang="en" suppressHydrationWarning>
-      <head>
-        <script
-          defer
-          src="/js/script.js"
-          data-api="/api/event"
-          data-domain="storybook.js.org"
-        ></script>
-      </head>
       <body
         className={cn(
           'min-h-screen bg-white font-sans antialiased dark:bg-slate-950',

--- a/apps/frontpage/app/layout.tsx
+++ b/apps/frontpage/app/layout.tsx
@@ -23,7 +23,7 @@ const fontSans = nunitoSans({
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://storybook.js.org'),
-  title: 'Storybook: Frontend workshop for UI development.',
+  title: 'Storybook: Frontend workshop for UI development',
   description:
     "Storybook is a frontend workshop for building UI components and pages in isolation. Thousands of teams use it for UI development, testing, and documentation. It's open source and free.",
   openGraph: {

--- a/apps/frontpage/app/layout.tsx
+++ b/apps/frontpage/app/layout.tsx
@@ -23,7 +23,7 @@ const fontSans = nunitoSans({
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://storybook.js.org'),
-  title: 'Storybook: Frontend workshop for UI development',
+  title: 'Storybook: Frontend workshop for UI development.',
   description:
     "Storybook is a frontend workshop for building UI components and pages in isolation. Thousands of teams use it for UI development, testing, and documentation. It's open source and free.",
   openGraph: {

--- a/apps/frontpage/app/providers.tsx
+++ b/apps/frontpage/app/providers.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from 'next-themes';
 import type { FC, ReactNode } from 'react';
 import posthog from 'posthog-js';
 import { PostHogProvider } from 'posthog-js/react';
+import PlausibleProvider from 'next-plausible';
 
 interface ProvidersProps {
   children: ReactNode;
@@ -18,8 +19,10 @@ if (typeof window !== 'undefined') {
 
 export const Providers: FC<ProvidersProps> = ({ children }) => {
   return (
-    <PostHogProvider client={posthog}>
-      <ThemeProvider attribute="class">{children}</ThemeProvider>
-    </PostHogProvider>
+    <PlausibleProvider domain="storybook.js.org">
+      <PostHogProvider client={posthog}>
+        <ThemeProvider attribute="class">{children}</ThemeProvider>
+      </PostHogProvider>
+    </PlausibleProvider>
   );
 };

--- a/apps/frontpage/middleware.ts
+++ b/apps/frontpage/middleware.ts
@@ -1,16 +1,50 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { cookieRenderId } from './constants';
+import { docsVersionsRedirects } from './redirects/docs-versions-redirects';
+import { RedirectData } from './redirects/types';
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   let searchParam = request.nextUrl.searchParams.get('renderer');
+  const pathname: string = request.nextUrl.pathname;
+  const redirectList: RedirectData[] = [...docsVersionsRedirects];
+  const redirectData = redirectList.find((r) => r.source === pathname);
 
-  const response = NextResponse.next();
+  if (
+    redirectData &&
+    typeof redirectData.destination === 'string' &&
+    typeof redirectData.permanent === 'boolean'
+  ) {
+    console.log(' Redirect to →', redirectData.destination);
+    const statusCode = redirectData.permanent ? 308 : 307;
+    return NextResponse.redirect(
+      new URL(redirectData.destination, request.url),
+      statusCode,
+    );
+  }
 
   // If the renderer query param is set, set the cookie
+  const response = NextResponse.next();
   if (searchParam) {
     response.cookies.set(cookieRenderId, searchParam);
   }
 
   return response;
 }
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - images (images public folder)
+     * - docs-assets (docs assets folder)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - icon.svg (favicon file)
+     * - favicon.ico (favicon file)
+     * - bubbles.png (docs background file)
+     */
+    '/((?!api|images|docs-assets|_next/static|_next/image|icon.svg|favicon.ico|bubbles.png).*)',
+  ],
+};

--- a/apps/frontpage/next.config.js
+++ b/apps/frontpage/next.config.js
@@ -34,7 +34,7 @@ const renderers = [
 ];
 
 /** @type {import('next').NextConfig} */
-module.exports = {
+module.exports = withPlausibleProxy()({
   images: {
     remotePatterns: [
       {
@@ -427,4 +427,4 @@ module.exports = {
     ];
   },
   pageExtensions: ['js', 'jsx', 'mdx', 'ts', 'tsx'],
-};
+});

--- a/apps/frontpage/next.config.js
+++ b/apps/frontpage/next.config.js
@@ -19,21 +19,6 @@ const historicalVersions = [
   '6.0',
 ];
 
-const renderers = [
-  'react',
-  'vue',
-  'angular',
-  'web-components',
-  'ember',
-  'html',
-  'mithril',
-  'marko',
-  'svelte',
-  'riot',
-  'preact',
-  'rax',
-];
-
 /** @type {import('next').NextConfig} */
 module.exports = withPlausibleProxy()({
   images: {
@@ -345,29 +330,6 @@ module.exports = withPlausibleProxy()({
         destination: '/docs/addons/writing-presets',
         permanent: true,
       },
-      ...renderers.map((r) => ({
-        source: `/docs${r}/get-started/examples`,
-        destination: '/showcase',
-        permanent: true,
-      })),
-      ...historicalVersions.map((v) => ({
-        source: `/docs/${v}`,
-        destination: `/docs/${v.split('.')[0]}/get-started/install`,
-        permanent: true,
-      })),
-      // The `/get-started` route is only valid for 8.0+
-      ...historicalVersions.reduce((acc, v) => {
-        if (Number(v) < 8) {
-          renderers.forEach((r) => {
-            acc.push({
-              source: `/docs/${v}/${r}/get-started`,
-              destination: `/docs/${v.split('.')[0]}/get-started/install`,
-              permanent: true,
-            });
-          });
-        }
-        return acc;
-      }, []),
       ...generatedRedirects,
       /* 🐺 Wild Cards */
       {

--- a/apps/frontpage/next.config.js
+++ b/apps/frontpage/next.config.js
@@ -1,4 +1,5 @@
 const generatedRedirects = require('./generated-redirects.json');
+const { withPlausibleProxy } = require('next-plausible');
 
 const historicalVersions = [
   '8.1',
@@ -80,7 +81,7 @@ module.exports = withPlausibleProxy()({
           value: 'noindex',
         },
       ],
-    }))
+    }));
   },
   // This was added to fix the error with remarkExpressiveCode
   // https://stackoverflow.com/questions/77009138/module-has-no-exports-error-works-fine-on-stackblitz-but-fails-locally

--- a/apps/frontpage/package.json
+++ b/apps/frontpage/package.json
@@ -53,6 +53,7 @@
     "image-size": "^1.1.1",
     "next": "^14.2.4",
     "next-mdx-remote": "^5.0.0",
+    "next-plausible": "^3.12.0",
     "next-sitemap": "^4.2.3",
     "next-themes": "^0.3.0",
     "node-fetch": "^3.3.2",

--- a/apps/frontpage/redirects/constants.ts
+++ b/apps/frontpage/redirects/constants.ts
@@ -1,0 +1,38 @@
+export const historicalVersions = [
+  '8.1',
+  '8.0',
+  '7.6',
+  '7.5',
+  '7.4',
+  '7.3',
+  '7.2',
+  '7.1',
+  '7.0',
+  '6.5',
+  '6.4',
+  '6.3',
+  '6.2',
+  '6.1',
+  '6.0',
+];
+
+export const versions8 = ['8', '8.1', '8.0'];
+
+export const versions7 = ['7.6', '7.5', '7.4', '7.3', '7.2', '7.1'];
+
+export const versions6 = ['6.5', '6.4', '6.3', '6.2', '6.1', '6.0'];
+
+export const renderers = [
+  'react',
+  'vue',
+  'angular',
+  'web-components',
+  'ember',
+  'html',
+  'mithril',
+  'marko',
+  'svelte',
+  'riot',
+  'preact',
+  'rax',
+];

--- a/apps/frontpage/redirects/docs-versions-redirects.ts
+++ b/apps/frontpage/redirects/docs-versions-redirects.ts
@@ -1,0 +1,35 @@
+import { renderers } from '@repo/utils';
+import {
+  historicalVersions,
+  versions6,
+  versions7,
+  versions8,
+} from './constants';
+import { RedirectData } from './types';
+
+export const docsVersionsRedirects: RedirectData[] = [
+  ...[...versions6, ...versions7].map((v) => ({
+    source: `/docs/${v}`,
+    destination: `/docs/${v.split('.')[0]}`,
+    permanent: true,
+  })),
+  ...versions8.map((v) => ({
+    source: `/docs/${v}`,
+    destination: `/docs`,
+    permanent: true,
+  })),
+  // The `/get-started` route is only valid for 8.0+
+  ...historicalVersions.reduce<RedirectData[]>((acc, v) => {
+    // Explicitly type the accumulator
+    if (Number(v) < 8) {
+      renderers.forEach((r) => {
+        acc.push({
+          source: `/docs/${v}/${r}/get-started`,
+          destination: `/docs/${v.split('.')[0]}/get-started/install`,
+          permanent: true,
+        });
+      });
+    }
+    return acc;
+  }, []),
+];

--- a/apps/frontpage/redirects/types.ts
+++ b/apps/frontpage/redirects/types.ts
@@ -1,0 +1,12 @@
+export interface RedirectList {
+  [key: string]: {
+    destination: string;
+    permanent: boolean;
+  };
+}
+
+export type RedirectData = {
+  source: string;
+  destination: string;
+  permanent: boolean;
+};

--- a/apps/frontpage/vercel.json
+++ b/apps/frontpage/vercel.json
@@ -33,14 +33,6 @@
       "destination": "https://storybook-dx.netlify.app/.netlify/functions/whats-new/:match*"
     },
     {
-      "source": "/js/script.js",
-      "destination": "https://plausible.io/js/script.js"
-    },
-    {
-      "source": "/api/event",
-      "destination": "https://plausible.io/api/event"
-    },
-    {
       "source": "/proxy/api/event",
       "destination": "https://plausible.io/api/event"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,6 +116,7 @@
         "image-size": "^1.1.1",
         "next": "^14.2.4",
         "next-mdx-remote": "^5.0.0",
+        "next-plausible": "^3.12.0",
         "next-sitemap": "^4.2.3",
         "next-themes": "^0.3.0",
         "node-fetch": "^3.3.2",
@@ -22298,6 +22299,19 @@
       },
       "peerDependencies": {
         "react": ">=16"
+      }
+    },
+    "node_modules/next-plausible": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.12.0.tgz",
+      "integrity": "sha512-SSkEqKQ6PgR8fx3sYfIAT69k2xuCUXO5ngkSS19CjxY97lAoZxsfZpYednxB4zo0mHYv87JzhPynrdBPlCBVHg==",
+      "funding": {
+        "url": "https://github.com/4lejandrito/next-plausible?sponsor=1"
+      },
+      "peerDependencies": {
+        "next": "^11.1.0 || ^12.0.0 || ^13.0.0 || ^14.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/next-sitemap": {


### PR DESCRIPTION
Since we started to have more than 1000 redirects in Next.js, we have to move them to middleware. This PR moves most of the redirects to middleware and attempt to fix Plausible using `withPlausibleProxy`