### PR TITLE
Update redirects with Next.js middleware

### DIFF
--- a/apps/frontpage/middleware.ts
+++ b/apps/frontpage/middleware.ts
@@ -4,7 +4,7 @@ import { cookieRenderId } from './constants';
 import { docsVersionsRedirects } from './redirects/docs-versions-redirects';
 import { RedirectData } from './redirects/types';
 import { docsRenderersRedirects } from './redirects/docs-renderers-redirects';
-import { docsGenericRedirects } from './redirects/docs-generic';
+import { docsCommonRedirects } from './redirects/docs-common-redirects';
 
 export async function middleware(request: NextRequest) {
   let searchParam = request.nextUrl.searchParams.get('renderer');
@@ -16,7 +16,7 @@ export async function middleware(request: NextRequest) {
   const redirectList: RedirectData[] = [
     ...docsVersionsRedirects,
     ...docsRenderersRedirects,
-    ...docsGenericRedirects,
+    ...docsCommonRedirects,
   ];
 
   for (const redirectData of redirectList) {

--- a/apps/frontpage/next.config.js
+++ b/apps/frontpage/next.config.js
@@ -93,255 +93,27 @@ module.exports = withPlausibleProxy()({
     // to avoid conflicts with the more specific redirects
     return [
       {
-        source: '/docs/get-started',
-        destination: '/docs',
-        permanent: true,
-      },
-      {
-        source: '/addons/addon-gallery',
-        destination: '/addons',
-        permanent: true,
-      },
-      {
-        source: '/integrations',
-        destination: '/addons',
-        permanent: true,
-      },
-      {
-        source: '/recipes',
-        destination: '/addons',
-        permanent: true,
-      },
-      {
         source: '/integrations/tag/:tag',
         destination: '/addons/tag/:tag',
         permanent: true,
-      },
-      {
-        source: '/telemetry',
-        destination: '/docs/configure/telemetry',
-        permanent: true,
-      },
-      {
-        source: '/status',
-        destination: 'https://github.com/storybookjs/storybook/issues/23279',
-        permanent: false,
       },
       {
         source: '/versions.json',
         destination: '/versions',
         permanent: true,
       },
-      {
-        source: '/design-system',
-        destination: 'https://master--5ccbc373887ca40020446347.chromatic.com',
-        permanent: true,
-      },
-      {
-        source: '/migration-guides/7.0',
-        destination: 'https://storybook.js.org/docs/7.0/migration-guide',
-        permanent: true,
-      },
-      {
-        source: '/migration-guides/8.0',
-        destination: 'https://storybook.js.org/docs/8.0/migration-guide',
-        permanent: true,
-      },
-      /* Supporting old docs URLs */
-      {
-        source: '/basics/slow-start-guide',
-        destination: '/docs/configure',
-        permanent: true,
-      },
-      {
-        source: '/docs/basics/slow-start-guide',
-        destination: '/docs/configure',
-        permanent: true,
-      },
-      {
-        source: '/docs/guides/slow-start-guide',
-        destination: '/docs/configure',
-        permanent: true,
-      },
-      {
-        source: '/basics/guide-react-native',
-        destination:
-          'https://github.com/storybookjs/react-native#storybook-for-react-native',
-        permanent: true,
-      },
-      {
-        source: '/docs/basics/guide-react-native',
-        destination:
-          'https://github.com/storybookjs/react-native#storybook-for-react-native',
-        permanent: true,
-      },
-      {
-        source: '/docs/guides/guide-react-native',
-        destination:
-          'https://github.com/storybookjs/react-native#storybook-for-react-native',
-        permanent: true,
-      },
-      {
-        source: '/docs/basics/writing-stories',
-        destination: '/docs/get-started/whats-a-story',
-        permanent: true,
-      },
-      {
-        source: '/docs/basics/exporting-storybook',
-        destination: '/docs/sharing/publish-storybook',
-        permanent: true,
-      },
-      {
-        source: '/docs/basics/faq',
-        destination: '/docs/faq',
-        permanent: true,
-      },
-      {
-        source: '/docs/basics/live-examples',
-        destination:
-          'https://github.com/storybookjs/storybook/blob/next/examples/README.md',
-        permanent: true,
-      },
-      {
-        source: '/docs/configurations/options-parameter',
-        destination: '/docs/configure/features-and-behavior',
-        permanent: true,
-      },
-      {
-        source: '/docs/configurations/custom-webpack-config',
-        destination: '/docs/builders/webpack',
-        permanent: true,
-      },
-      {
-        source: '/docs/configurations/custom-babel-config',
-        destination: '/docs/configure/compilers',
-        permanent: true,
-      },
-      {
-        source: '/docs/configurations/typescript-config',
-        destination: '/docs/configure/typescript',
-        permanent: true,
-      },
-      {
-        source: '/docs/configurations/add-custom-head-tags',
-        destination: '/docs/configure/story-rendering#adding-to-head',
-        permanent: true,
-      },
-      {
-        source: '/docs/configurations/add-custom-body',
-        destination: '/docs/configure/story-rendering#adding-to-body',
-        permanent: true,
-      },
-      {
-        source: '/docs/configurations/serving-static-files',
-        destination:
-          '/docs/configure/images-and-assets#serving-static-files-via-storybook',
-        permanent: true,
-      },
-      {
-        source: '/docs/configurations/env-vars',
-        destination: '/docs/configure/environment-variables',
-        permanent: true,
-      },
-      {
-        source: '/docs/configurations/theming',
-        destination: '/docs/configure/theming',
-        permanent: true,
-      },
-      {
-        source: '/docs/configurations/cli-options',
-        destination: '/docs/api/cli-options',
-        permanent: true,
-      },
-      {
-        source: '/docs/configurations/standalone-options',
-        destination:
-          'https://github.com/storybookjs/storybook/blob/next/lib/core/docs/standalone.md',
-        permanent: true,
-      },
-      {
-        source: '/docs/formats/component-story-format',
-        destination: '/docs/api/csf',
-        permanent: true,
-      },
-      {
-        source: '/docs/formats/storiesof-api',
-        destination:
-          'https://github.com/storybookjs/storybook/blob/next/lib/core/docs/storiesOf.md',
-        permanent: true,
-      },
-      {
-        source: '/docs/formats/mdx-syntax',
-        destination: '/docs/writing-docs/mdx',
-        permanent: true,
-      },
-      {
-        source: '/docs/testing/react-ui-testing',
-        destination: '/docs/writing-tests',
-        permanent: true,
-      },
-      {
-        source: '/docs/testing/structural-testing',
-        destination: '/docs/writing-tests/snapshot-testing',
-        permanent: true,
-      },
-      {
-        source: '/docs/testing/interaction-testing',
-        destination: '/docs/writing-tests/interaction-testing',
-        permanent: true,
-      },
-      {
-        source: '/docs/testing/automated-visual-testing',
-        destination: '/docs/writing-tests/visual-testing',
-        permanent: true,
-      },
-      {
-        source: '/docs/testing/manual-testing',
-        destination: '/docs/writing-tests',
-        permanent: true,
-      },
-      {
-        source: '/docs/addons/using-addons',
-        destination: '/docs/addons/install-addons',
-        permanent: true,
-      },
-      {
-        source: '/addons/writing-addons',
-        destination: '/docs/addons/writing-addons',
-        permanent: true,
-      },
-      {
-        source: '/docs/addons/api',
-        destination: '/docs/addons/addons-api',
-        permanent: true,
-      },
-      {
-        source: '/docs/presets/introduction',
-        destination: '/docs/addons/writing-presets',
-        permanent: true,
-      },
-      {
-        source: '/docs/presets/preset-gallery',
-        destination: 'https://github.com/storybookjs/presets',
-        permanent: true,
-      },
-      {
-        source: '/docs/presets/writing-presets',
-        destination: '/docs/addons/writing-presets',
-        permanent: true,
-      },
       ...generatedRedirects,
       /* 🐺 Wild Cards */
-      {
-        source: '/basics/:path*',
-        destination: '/docs',
-        permanent: true,
-      },
-      {
-        source: '/docs/basics/:path*',
-        destination: '/docs',
-        permanent: true,
-      },
+      // {
+      //   source: '/basics/:path*',
+      //   destination: '/docs',
+      //   permanent: true,
+      // },
+      // {
+      //   source: '/docs/basics/:path*',
+      //   destination: '/docs',
+      //   permanent: true,
+      // },
       {
         source: '/configurations/:path*',
         destination: '/docs/configure',

--- a/apps/frontpage/next.config.js
+++ b/apps/frontpage/next.config.js
@@ -89,77 +89,7 @@ module.exports = withPlausibleProxy()({
     },
   },
   async redirects() {
-    // Add the wild cards at the bottom of the list
-    // to avoid conflicts with the more specific redirects
-    return [
-      {
-        source: '/integrations/tag/:tag',
-        destination: '/addons/tag/:tag',
-        permanent: true,
-      },
-      {
-        source: '/versions.json',
-        destination: '/versions',
-        permanent: true,
-      },
-      ...generatedRedirects,
-      /* 🐺 Wild Cards */
-      // {
-      //   source: '/basics/:path*',
-      //   destination: '/docs',
-      //   permanent: true,
-      // },
-      // {
-      //   source: '/docs/basics/:path*',
-      //   destination: '/docs',
-      //   permanent: true,
-      // },
-      {
-        source: '/configurations/:path*',
-        destination: '/docs/configure',
-        permanent: true,
-      },
-      {
-        source: '/docs/configurations/:path*',
-        destination: '/docs/configure',
-        permanent: true,
-      },
-      {
-        source: '/examples/:path*',
-        destination: '/docs',
-        permanent: true,
-      },
-      {
-        source: '/docs/examples/:path*',
-        destination: '/docs',
-        permanent: true,
-      },
-      {
-        source: '/logos/:path*',
-        destination: '/docs',
-        permanent: true,
-      },
-      {
-        source: '/docs/logos/:path*',
-        destination: '/docs',
-        permanent: true,
-      },
-      {
-        source: '/testing/:path*',
-        destination: '/docs',
-        permanent: true,
-      },
-      {
-        source: '/docs/testing/:path*',
-        destination: '/docs/writing-tests',
-        permanent: true,
-      },
-      {
-        source: '/docs/guides/:path*',
-        destination: '/docs',
-        permanent: true,
-      },
-    ];
+    return [...generatedRedirects];
   },
   pageExtensions: ['js', 'jsx', 'mdx', 'ts', 'tsx'],
 });

--- a/apps/frontpage/redirects/docs-common-redirects.ts
+++ b/apps/frontpage/redirects/docs-common-redirects.ts
@@ -2,6 +2,11 @@ import { RedirectData } from './types';
 
 export const docsCommonRedirects: RedirectData[] = [
   {
+    source: '/versions.json',
+    destination: '/versions',
+    permanent: true,
+  },
+  {
     source: '/docs/get-started',
     destination: '/docs',
     permanent: true,
@@ -14,6 +19,11 @@ export const docsCommonRedirects: RedirectData[] = [
   {
     source: '/integrations',
     destination: '/addons',
+    permanent: true,
+  },
+  {
+    source: '/integrations/tag/:tag',
+    destination: '/addons/tag/:tag',
     permanent: true,
   },
   {
@@ -231,8 +241,58 @@ export const docsCommonRedirects: RedirectData[] = [
   },
   /* 🐺 Wild Cards */
   {
-    source: '/basics/:path/coco',
-    destination: '/docs/:path/coco',
+    source: '/basics/:path*',
+    destination: '/docs',
+    permanent: true,
+  },
+  {
+    source: '/docs/basics/:path*',
+    destination: '/docs',
+    permanent: true,
+  },
+  {
+    source: '/configurations/:path*',
+    destination: '/docs/configure',
+    permanent: true,
+  },
+  {
+    source: '/docs/configurations/:path*',
+    destination: '/docs/configure',
+    permanent: true,
+  },
+  {
+    source: '/examples/:path*',
+    destination: '/docs',
+    permanent: true,
+  },
+  {
+    source: '/docs/examples/:path*',
+    destination: '/docs',
+    permanent: true,
+  },
+  {
+    source: '/logos/:path*',
+    destination: '/docs',
+    permanent: true,
+  },
+  {
+    source: '/docs/logos/:path*',
+    destination: '/docs',
+    permanent: true,
+  },
+  {
+    source: '/testing/:path*',
+    destination: '/docs',
+    permanent: true,
+  },
+  {
+    source: '/docs/testing/:path*',
+    destination: '/docs/writing-tests',
+    permanent: true,
+  },
+  {
+    source: '/docs/guides/:path*',
+    destination: '/docs',
     permanent: true,
   },
 ];

--- a/apps/frontpage/redirects/docs-common-redirects.ts
+++ b/apps/frontpage/redirects/docs-common-redirects.ts
@@ -22,8 +22,8 @@ export const docsCommonRedirects: RedirectData[] = [
     permanent: true,
   },
   {
-    source: '/integrations/tag/:tag',
-    destination: '/addons/tag/:tag',
+    source: '/integrations/tag/:path',
+    destination: '/addons/tag/:path',
     permanent: true,
   },
   {

--- a/apps/frontpage/redirects/docs-common-redirects.ts
+++ b/apps/frontpage/redirects/docs-common-redirects.ts
@@ -48,12 +48,13 @@ export const docsCommonRedirects: RedirectData[] = [
   },
   {
     source: '/migration-guides/7.0',
-    destination: '/docs/7.0/migration-guide',
+    destination: '/docs/7/migration-guide',
     permanent: true,
   },
+  // TODO: Make sure this one works after 9.0
   {
     source: '/migration-guides/8.0',
-    destination: '/docs/8.0/migration-guide',
+    destination: '/docs/migration-guide',
     permanent: true,
   },
   /* Supporting old docs URLs */
@@ -105,6 +106,7 @@ export const docsCommonRedirects: RedirectData[] = [
     destination: '/docs/faq',
     permanent: true,
   },
+  // TODO: Fix - This is a 404
   {
     source: '/docs/basics/live-examples',
     destination:

--- a/apps/frontpage/redirects/docs-common-redirects.ts
+++ b/apps/frontpage/redirects/docs-common-redirects.ts
@@ -1,0 +1,238 @@
+import { RedirectData } from './types';
+
+export const docsCommonRedirects: RedirectData[] = [
+  {
+    source: '/docs/get-started',
+    destination: '/docs',
+    permanent: true,
+  },
+  {
+    source: '/addons/addon-gallery',
+    destination: '/addons',
+    permanent: true,
+  },
+  {
+    source: '/integrations',
+    destination: '/addons',
+    permanent: true,
+  },
+  {
+    source: '/recipes',
+    destination: '/addons',
+    permanent: true,
+  },
+  {
+    source: '/telemetry',
+    destination: '/docs/configure/telemetry',
+    permanent: true,
+  },
+  {
+    source: '/status',
+    destination: 'https://github.com/storybookjs/storybook/issues/23279',
+    permanent: false,
+  },
+  {
+    source: '/design-system',
+    destination: 'https://master--5ccbc373887ca40020446347.chromatic.com',
+    permanent: true,
+  },
+  {
+    source: '/migration-guides/7.0',
+    destination: '/docs/7.0/migration-guide',
+    permanent: true,
+  },
+  {
+    source: '/migration-guides/8.0',
+    destination: '/docs/8.0/migration-guide',
+    permanent: true,
+  },
+  /* Supporting old docs URLs */
+  {
+    source: '/basics/slow-start-guide',
+    destination: '/docs/configure',
+    permanent: true,
+  },
+  {
+    source: '/docs/basics/slow-start-guide',
+    destination: '/docs/configure',
+    permanent: true,
+  },
+  {
+    source: '/docs/guides/slow-start-guide',
+    destination: '/docs/configure',
+    permanent: true,
+  },
+  {
+    source: '/basics/guide-react-native',
+    destination:
+      'https://github.com/storybookjs/react-native#storybook-for-react-native',
+    permanent: true,
+  },
+  {
+    source: '/docs/basics/guide-react-native',
+    destination:
+      'https://github.com/storybookjs/react-native#storybook-for-react-native',
+    permanent: true,
+  },
+  {
+    source: '/docs/guides/guide-react-native',
+    destination:
+      'https://github.com/storybookjs/react-native#storybook-for-react-native',
+    permanent: true,
+  },
+  {
+    source: '/docs/basics/writing-stories',
+    destination: '/docs/get-started/whats-a-story',
+    permanent: true,
+  },
+  {
+    source: '/docs/basics/exporting-storybook',
+    destination: '/docs/sharing/publish-storybook',
+    permanent: true,
+  },
+  {
+    source: '/docs/basics/faq',
+    destination: '/docs/faq',
+    permanent: true,
+  },
+  {
+    source: '/docs/basics/live-examples',
+    destination:
+      'https://github.com/storybookjs/storybook/blob/next/examples/README.md',
+    permanent: true,
+  },
+  {
+    source: '/docs/configurations/options-parameter',
+    destination: '/docs/configure/features-and-behavior',
+    permanent: true,
+  },
+  {
+    source: '/docs/configurations/custom-webpack-config',
+    destination: '/docs/builders/webpack',
+    permanent: true,
+  },
+  {
+    source: '/docs/configurations/custom-babel-config',
+    destination: '/docs/configure/compilers',
+    permanent: true,
+  },
+  {
+    source: '/docs/configurations/typescript-config',
+    destination: '/docs/configure/typescript',
+    permanent: true,
+  },
+  {
+    source: '/docs/configurations/add-custom-head-tags',
+    destination: '/docs/configure/story-rendering#adding-to-head',
+    permanent: true,
+  },
+  {
+    source: '/docs/configurations/add-custom-body',
+    destination: '/docs/configure/story-rendering#adding-to-body',
+    permanent: true,
+  },
+  {
+    source: '/docs/configurations/serving-static-files',
+    destination:
+      '/docs/configure/images-and-assets#serving-static-files-via-storybook',
+    permanent: true,
+  },
+  {
+    source: '/docs/configurations/env-vars',
+    destination: '/docs/configure/environment-variables',
+    permanent: true,
+  },
+  {
+    source: '/docs/configurations/theming',
+    destination: '/docs/configure/theming',
+    permanent: true,
+  },
+  {
+    source: '/docs/configurations/cli-options',
+    destination: '/docs/api/cli-options',
+    permanent: true,
+  },
+  {
+    source: '/docs/configurations/standalone-options',
+    destination:
+      'https://github.com/storybookjs/storybook/blob/next/lib/core/docs/standalone.md',
+    permanent: true,
+  },
+  {
+    source: '/docs/formats/component-story-format',
+    destination: '/docs/api/csf',
+    permanent: true,
+  },
+  {
+    source: '/docs/formats/storiesof-api',
+    destination:
+      'https://github.com/storybookjs/storybook/blob/next/lib/core/docs/storiesOf.md',
+    permanent: true,
+  },
+  {
+    source: '/docs/formats/mdx-syntax',
+    destination: '/docs/writing-docs/mdx',
+    permanent: true,
+  },
+  {
+    source: '/docs/testing/react-ui-testing',
+    destination: '/docs/writing-tests',
+    permanent: true,
+  },
+  {
+    source: '/docs/testing/structural-testing',
+    destination: '/docs/writing-tests/snapshot-testing',
+    permanent: true,
+  },
+  {
+    source: '/docs/testing/interaction-testing',
+    destination: '/docs/writing-tests/interaction-testing',
+    permanent: true,
+  },
+  {
+    source: '/docs/testing/automated-visual-testing',
+    destination: '/docs/writing-tests/visual-testing',
+    permanent: true,
+  },
+  {
+    source: '/docs/testing/manual-testing',
+    destination: '/docs/writing-tests',
+    permanent: true,
+  },
+  {
+    source: '/docs/addons/using-addons',
+    destination: '/docs/addons/install-addons',
+    permanent: true,
+  },
+  {
+    source: '/addons/writing-addons',
+    destination: '/docs/addons/writing-addons',
+    permanent: true,
+  },
+  {
+    source: '/docs/addons/api',
+    destination: '/docs/addons/addons-api',
+    permanent: true,
+  },
+  {
+    source: '/docs/presets/introduction',
+    destination: '/docs/addons/writing-presets',
+    permanent: true,
+  },
+  {
+    source: '/docs/presets/preset-gallery',
+    destination: 'https://github.com/storybookjs/presets',
+    permanent: true,
+  },
+  {
+    source: '/docs/presets/writing-presets',
+    destination: '/docs/addons/writing-presets',
+    permanent: true,
+  },
+  /* 🐺 Wild Cards */
+  {
+    source: '/basics/:path/coco',
+    destination: '/docs/:path/coco',
+    permanent: true,
+  },
+];

--- a/apps/frontpage/redirects/docs-versions-redirects.ts
+++ b/apps/frontpage/redirects/docs-versions-redirects.ts
@@ -20,19 +20,19 @@ export const docsVersionsRedirects: RedirectData[] = [
   })),
   // TODO: Not sure about this one - Verify with Kyle
   // The `/get-started` route is only valid for 8.0+
-  // ...historicalVersions.reduce<RedirectData[]>((acc, v) => {
-  //   // Explicitly type the accumulator
-  //   if (Number(v) < 8) {
-  //     renderers.forEach((r) => {
-  //       acc.push({
-  //         source: `/docs/${v}/${r}/get-started`,
-  //         destination: `/docs/${v.split('.')[0]}/get-started/install`,
-  //         permanent: true,
-  //       });
-  //     });
-  //   }
-  //   return acc;
-  // }, []),
+  ...historicalVersions.reduce<RedirectData[]>((acc, v) => {
+    // Explicitly type the accumulator
+    if (Number(v) < 8) {
+      renderers.forEach((r) => {
+        acc.push({
+          source: `/docs/${v}/${r}/get-started`,
+          destination: `/docs/${v.split('.')[0]}/get-started/install`,
+          permanent: true,
+        });
+      });
+    }
+    return acc;
+  }, []),
   {
     source: '/docs/6/get-started',
     destination: '/docs/6',


### PR DESCRIPTION
Nextjs config has a limit of 1000 redirects. With Plausible proxy, we pushed the limit so the best option was to move redirects to the middleware to be able to scale. The problem is that some patterns that we had for free in Next.js are not built for us in the middleware. In this PR we are creating the new redirect rules as well as importing the most common redirects.

[More info about redirecting at scale with Next.js](https://nextjs.org/docs/pages/building-your-application/routing/redirecting#managing-redirects-at-scale-advanced)