### PR TITLE
Move addons catalog sitemap to frontpage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,18 @@ apps/frontpage/content/docs
 apps/frontpage/content/snippets
 apps/frontpage/generated-redirects.json
 apps/frontpage/public/docs-assets
-apps/frontpage/public/sitemap
+
 apps/tutorials/public/sitemap.xml
 robots.txt
+
+# Sitemaps
+apps/frontpage/public/sitemap/sitemap.xml
+apps/frontpage/public/sitemap/sitemap-all.xml
+apps/frontpage/public/sitemap/sitemap-all-0.xml
+apps/frontpage/public/sitemap/sitemap-0.xml
+apps/frontpage/public/sitemap/tutorials/sitemap.xml
+apps/frontpage/public/sitemap/blog/sitemap.xml
+apps/frontpage/public/sitemap/showcase/sitemap.xml
 
 # ui
 dist/

--- a/apps/frontpage/public/sitemap/addons/sitemap.xml
+++ b/apps/frontpage/public/sitemap/addons/sitemap.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://storybook.js.org/addons</loc><lastmod>2024-07-01T22:37:52.321Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+</urlset>

--- a/apps/frontpage/scripts/copy-other-sitemaps.ts
+++ b/apps/frontpage/scripts/copy-other-sitemaps.ts
@@ -9,11 +9,6 @@ async function getRemoteSitemapContent(p: string): Promise<string> {
 }
 
 const OTHER_SITEMAPS = {
-  addons: {
-    async getContent() {
-      return await fs.readFile(path.join(__dirname, '../../..', 'apps/addon-catalog/public/sitemap.xml'), 'utf-8');
-    },
-  },
   blog: {
     async getContent() {
       return getRemoteSitemapContent('/blog/sitemap/sitemap-0.xml');


### PR DESCRIPTION
We used to have a lot of random issues trying to find the addons catalog sitemap when deploying to Vercel. Since the sitemap is quite static, I moved it to frontpage and removed it to the script to generate sitemaps.

Here's a fail build on Vercel - https://vercel.com/storybookjs/web/6YX1Px4MxV1BvEytp7c8j9bGefHo?filter=errors