### PR TITLE
Improve set renderer cookie from params

### DIFF
--- a/apps/frontpage/app/docs/layout.tsx
+++ b/apps/frontpage/app/docs/layout.tsx
@@ -6,10 +6,11 @@ import { NavDocs } from '../../components/docs/sidebar/docs-nav';
 import { DocsProvider } from './provider';
 import { Submenu } from '../../components/docs/submenu';
 import { DocsMainNav } from '../../components/docs/sidebar/docs-main-nav';
-import { ReactNode } from 'react';
+import { ReactNode, Suspense } from 'react';
 import { TOCSectionTitles } from '../../components/docs/toc-section-titles';
 import { getAllTrees } from '../../lib/get-all-trees';
 import { Metadata } from 'next';
+import { RendererCookie } from './renderer-cookie';
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -23,6 +24,13 @@ export default async function Layout({ children }: { children: ReactNode }) {
 
   return (
     <DocsProvider>
+      {/*
+        We have to wrap it with suspense to use useSearchParams() while still make the rest statically generated.
+        https://nextjs.org/docs/app/api-reference/functions/use-search-params#static-rendering
+      */}
+      <Suspense fallback={null}>
+        <RendererCookie />
+      </Suspense>
       <Header
         algoliaApiKey={process.env.NEXT_PUBLIC_ALGOLIA_API_KEY as string}
         githubCount={githubCount}

--- a/apps/frontpage/app/docs/provider.tsx
+++ b/apps/frontpage/app/docs/provider.tsx
@@ -9,6 +9,7 @@ import {
   cookiePackageManagerId,
   cookieRenderId,
 } from '../../constants';
+import { useSearchParams } from 'next/navigation';
 
 export interface DocsContextProps {
   activeRenderer: null | string;
@@ -24,8 +25,15 @@ export const DocsContext = createContext<DocsContextProps | undefined>(
 );
 
 export function DocsProvider({ children }: { children: ReactNode }) {
-  const [activeRenderer, setActiveRenderer] = useState<null | string>(renderers[0].id);
-  const [activeLanguage, setActiveLanguage] = useState<null | string>(languages[0].id);
+  const searchParams = useSearchParams();
+  const rendererParam = searchParams.get('renderer');
+
+  const [activeRenderer, setActiveRenderer] = useState<null | string>(
+    renderers[0].id,
+  );
+  const [activeLanguage, setActiveLanguage] = useState<null | string>(
+    languages[0].id,
+  );
   const [activePackageManager, setActivePackageManager] = useState<
     null | string
   >(packageManagers[0].id);
@@ -53,6 +61,13 @@ export function DocsProvider({ children }: { children: ReactNode }) {
       setCookie(cookiePackageManagerId, packageManagers[0].id);
     }
   }, []);
+
+  useEffect(() => {
+    if (rendererParam) {
+      setActiveRenderer(rendererParam);
+      setCookie(cookieRenderId, rendererParam);
+    }
+  }, [rendererParam]);
 
   const setRenderer = (id: string) => {
     setActiveRenderer(id);

--- a/apps/frontpage/app/docs/provider.tsx
+++ b/apps/frontpage/app/docs/provider.tsx
@@ -25,9 +25,6 @@ export const DocsContext = createContext<DocsContextProps | undefined>(
 );
 
 export function DocsProvider({ children }: { children: ReactNode }) {
-  const searchParams = useSearchParams();
-  const rendererParam = searchParams.get('renderer');
-
   const [activeRenderer, setActiveRenderer] = useState<null | string>(
     renderers[0].id,
   );
@@ -61,13 +58,6 @@ export function DocsProvider({ children }: { children: ReactNode }) {
       setCookie(cookiePackageManagerId, packageManagers[0].id);
     }
   }, []);
-
-  useEffect(() => {
-    if (rendererParam) {
-      setActiveRenderer(rendererParam);
-      setCookie(cookieRenderId, rendererParam);
-    }
-  }, [rendererParam]);
 
   const setRenderer = (id: string) => {
     setActiveRenderer(id);

--- a/apps/frontpage/app/docs/renderer-cookie.tsx
+++ b/apps/frontpage/app/docs/renderer-cookie.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+import { useDocs } from './provider';
+
+export const RendererCookie = () => {
+  const { setRenderer } = useDocs();
+  const searchParams = useSearchParams();
+  const rendererParam = searchParams.get('renderer');
+
+  useEffect(() => {
+    if (rendererParam) setRenderer(rendererParam);
+  }, [rendererParam]);
+  return null;
+};

--- a/apps/frontpage/app/docs/renderer-cookie.tsx
+++ b/apps/frontpage/app/docs/renderer-cookie.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 import { useDocs } from './provider';
+import { renderers } from '@repo/utils';
 
 export const RendererCookie = () => {
   const { setRenderer } = useDocs();
@@ -10,7 +11,14 @@ export const RendererCookie = () => {
   const rendererParam = searchParams.get('renderer');
 
   useEffect(() => {
-    if (rendererParam) setRenderer(rendererParam);
+    if (rendererParam) {
+      const findRenderer = renderers.find(
+        (renderer) => renderer.id === rendererParam,
+      );
+      if (findRenderer) {
+        setRenderer(rendererParam);
+      }
+    }
   }, [rendererParam]);
   return null;
 };

--- a/apps/frontpage/middleware.ts
+++ b/apps/frontpage/middleware.ts
@@ -67,20 +67,7 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  // If the renderer query param is set, set the cookie
-  const response = NextResponse.next();
-
-  if (searchParam) {
-    const findRenderer = renderers.find(
-      (renderer) => renderer.id === searchParam,
-    );
-
-    if (findRenderer) {
-      response.cookies.set(cookieRenderId, searchParam);
-    }
-  }
-
-  return response;
+  return NextResponse.next();
 }
 
 export const config = {

--- a/apps/frontpage/middleware.ts
+++ b/apps/frontpage/middleware.ts
@@ -5,6 +5,7 @@ import { docsVersionsRedirects } from './redirects/docs-versions-redirects';
 import { RedirectData } from './redirects/types';
 import { docsRenderersRedirects } from './redirects/docs-renderers-redirects';
 import { docsCommonRedirects } from './redirects/docs-common-redirects';
+import { renderers } from '@repo/utils';
 
 export async function middleware(request: NextRequest) {
   let searchParam = request.nextUrl.searchParams.get('renderer');
@@ -68,8 +69,15 @@ export async function middleware(request: NextRequest) {
 
   // If the renderer query param is set, set the cookie
   const response = NextResponse.next();
+
   if (searchParam) {
-    response.cookies.set(cookieRenderId, searchParam);
+    const findRenderer = renderers.find(
+      (renderer) => renderer.id === searchParam,
+    );
+
+    if (findRenderer) {
+      response.cookies.set(cookieRenderId, searchParam);
+    }
   }
 
   return response;

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,8 @@
     "generate-redirects": {
       "dependsOn": [],
       "inputs": ["./apps/frontpage/scripts/raw-redirects"],
-      "outputs": ["./apps/frontpage/generated-redirects.json"]
+      "outputs": ["./apps/frontpage/generated-redirects.json"],
+      "cache": false
     },
     "fetch-docs": {
       "dependsOn": [],


### PR DESCRIPTION
- I moved the function to set the cookie based on the query params from middleware to a client component. To make it work while still allow for the rest of the page to be statically rendered at build time I had to wrap this component in a suspense boundary.
- We are now only setting the cookie if it exists in the available list of renderers.