### PR TITLE
Add `react-native-web` renderer

### DIFF
--- a/apps/frontpage/components/docs/mdx/code-snippets/code-snippets.stories.tsx
+++ b/apps/frontpage/components/docs/mdx/code-snippets/code-snippets.stories.tsx
@@ -25,6 +25,7 @@ const meta = {
         'vue',
         'angular',
         'web-components',
+        'react-native-web',
         'ember',
         'html',
         'svelte',
@@ -144,6 +145,13 @@ export const AngularNoLanguage: Story = {
   args: {
     content: content2,
     activeRenderer: 'angular',
+  },
+};
+
+export const ReactNativeWebFallbackToReact: Story = {
+  args: {
+    content: content2,
+    activeRenderer: 'react-native-web',
   },
 };
 

--- a/apps/frontpage/components/docs/mdx/code-snippets/utils/get-active-content.ts
+++ b/apps/frontpage/components/docs/mdx/code-snippets/utils/get-active-content.ts
@@ -45,7 +45,10 @@ export const getActiveContentTabs = ({
     } else {
       // If there's react content, we need to show that
       filteredContent = reactContent;
-      error = `This snippet doesn't exist for ${activeRenderer ?? ''}. In the meantime, here's the React snippet.`;
+      // RNW snippets fallback to React snippets with no warning
+      if (activeRenderer !== 'react-native-web') {
+        error = `This snippet doesn't exist for ${activeRenderer ?? ''}. In the meantime, here's the React snippet.`;
+      }
     }
   }
 

--- a/packages/utils/src/docs-renderers.tsx
+++ b/packages/utils/src/docs-renderers.tsx
@@ -10,6 +10,7 @@ export const renderers = [
   { id: "vue", title: "Vue" },
   { id: "angular", title: "Angular" },
   { id: "web-components", title: "Web Components" },
+  { id: "react-native-web", title: "React Native Web" },
   { id: "ember", title: "Ember" },
   { id: "html", title: "HTML" },
   { id: "svelte", title: "Svelte" },


### PR DESCRIPTION
- Falls back to `react` (without missing snippet warning)