### PR TITLE
Fix the install button on the addon page

### DIFF
--- a/apps/addon-catalog/components/addon/addon-hero.tsx
+++ b/apps/addon-catalog/components/addon/addon-hero.tsx
@@ -17,7 +17,7 @@ export function AddonHero({ addon }: { addon: Addon }) {
   const [state, setState] = useState(false);
 
   const onClick = () => {
-    copy(`npx install ${addon.name ?? ''}`);
+    copy(`npm install ${addon.name ?? ''}`);
     setState(true);
     setTimeout(() => {
       setState(false);


### PR DESCRIPTION
This PR fixes a bug on the addon page on the Storybook website (https://storybook.js.org/addons/@storybook/addon-themes).

Currently, the install command shown is <code><strong>npm</strong> install {addon}</code>, but when clicking it, <code><strong>npx</strong> install {addon}</code> is the command that is copied to the clipboard.


https://github.com/user-attachments/assets/548b3e9d-c012-4a01-a22a-0449b10a00be

