### PR TITLE
fix: replaced typo npx with npm on addon-hero.tsx

### DIFF
--- a/apps/addon-catalog/components/addon/addon-hero.tsx
+++ b/apps/addon-catalog/components/addon/addon-hero.tsx
@@ -17,7 +17,7 @@ export function AddonHero({ addon }: { addon: Addon }) {
   const [state, setState] = useState(false);
 
   const onClick = () => {
-    copy(`npx install ${addon.name ?? ''}`);
+    copy(`npm install ${addon.name ?? ''}`);
     setState(true);
     setTimeout(() => {
       setState(false);


### PR DESCRIPTION
the copy function was copying "npx", the text says "npm", as a result, pasting the copied text does not work, however npm install addon-name works fine. So I figured this is the problem.