### PR TITLE
Re-add docs page tabs

### DIFF
--- a/apps/frontpage/components/docs/content.tsx
+++ b/apps/frontpage/components/docs/content.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@repo/utils';
 import { type FC } from 'react';
+import Link from 'next/link';
+import { cn } from '@repo/utils';
 import { type PageDataProps } from '../../lib/get-page';
 import { Renderers } from './renderers';
 import { DocsFooter } from './footer/footer';
@@ -8,36 +9,56 @@ import { TableOfContent } from './table-of-content';
 export const Content: FC<{ page: PageDataProps }> = ({ page }) => {
   return (
     <>
-      <div className="flex-1 w-full min-w-0 py-12">
+      <div className="w-full min-w-0 flex-1 py-12">
         <main className="mx-auto max-w-[720px]">
           <h1
-            className="relative mt-0 mb-6 text-4xl font-bold text-black transition-colors duration-200 group-hover:text-blue-500 dark:text-white"
+            className="relative mb-6 mt-0 text-4xl font-bold text-black transition-colors duration-200 group-hover:text-blue-500 dark:text-white"
             data-docs-heading
           >
             {page.title ?? 'Title is missing'}
           </h1>
           {!page.hideRendererSelector && <Renderers />}
-          {/* TODO: Bring back tabs */}
-          {/* {page.tabs && page.tabs.length > 0 ? (
-        <div className="flex items-center gap-8 border-b border-zinc-200">
-          {page.tabs.map((tab) => {
-            const isActive = tab.slug === `/docs/${slug?.join('/')}`;
-
-            return (
-              <Link
-                className={cn(
+          {page.tabs && page.tabs.length > 0 ? (
+            <div className="flex items-center gap-8 border-b border-zinc-200">
+              {page.tabs.map((tab) => {
+                const tabTitle = tab.tab?.title ?? tab.title;
+                const isActive = tab.pathSegment === page.path;
+                const className = cn(
                   '-mb-px border-b px-2 pb-2 text-sm capitalize transition-colors hover:text-blue-500',
                   isActive && 'border-b border-blue-500 text-blue-500',
-                )}
-                href={tab.slug}
-                key={tab.name}
-              >
-                {tab.tab?.title || tab.title}
-              </Link>
-            );
-          })}
-        </div>
-      ) : null} */}
+                );
+
+                if (isActive) {
+                  return (
+                    <span className={className} key={tab.name}>
+                      {tabTitle}
+                    </span>
+                  );
+                }
+
+                const relevantPathSegments = (
+                  tab.name === 'index.mdx'
+                    ? tab.pathSegment.split('/').slice(-2, -1)
+                    : tab.pathSegment.split('/').slice(-2)
+                )
+                  .join('/')
+                  .replace('.mdx', '');
+                const href = page.isIndexPage
+                  ? `./${relevantPathSegments}`
+                  : `../${relevantPathSegments}`;
+
+                return (
+                  <Link
+                    className={className}
+                    href={href}
+                    key={tab.name}
+                  >
+                    {tabTitle}
+                  </Link>
+                );
+              })}
+            </div>
+          ) : null}
           <div
             className={cn(
               '[&>details]:my-6',

--- a/apps/frontpage/lib/get-docs-tree-from-path.ts
+++ b/apps/frontpage/lib/get-docs-tree-from-path.ts
@@ -84,6 +84,10 @@ export const getDocsTreeFromPath = (
     a.sidebar?.order && b.sidebar?.order
       ? a.sidebar.order - b.sidebar.order
       : 0,
+  ).sort((a, b) =>
+    a.tab?.order && b.tab?.order
+      ? a.tab.order - b.tab.order
+      : 0,
   );
   // TODO: Remove the index page from the tree, probably from pathSegment instead of slug
   // .filter((item) => {

--- a/apps/frontpage/lib/get-page.tsx
+++ b/apps/frontpage/lib/get-page.tsx
@@ -23,6 +23,7 @@ export interface PageDataProps {
   isIndexPage: boolean;
   tabs: RawTreeProps[];
   content: ReactElement;
+  path: string;
 }
 
 export const getPageData = async (
@@ -109,6 +110,7 @@ export const getPageData = async (
   return {
     ...frontmatter,
     isIndexPage: isIndexMDX || isIndexMD,
+    path: newPath,
     tabs: index?.isTab ? parent : [],
     content,
   };


### PR DESCRIPTION
![The Component Story Format (CSF) page showing two page-level tabs, CSF 3 and CSF Factories (Experimental). The second tab is active.](https://github.com/user-attachments/assets/b0175219-547e-41d7-a027-edcdff879cf0)

## How to test

To see the docs page tabs, the content had to be updated. Therefore, a [demo PR](https://github.com/storybookjs/web/pull/260) was created for testing.

_You **will not** be able to test in this PR's deploy preview._

1. You should see functional page-level tabs on this page (which is built from [these content changes](https://github.com/storybookjs/storybook/pull/30343/commits/e1c2cdc22e79bc375c0c4c8eef05ce5643cb9ad5)):

   https://deploy-preview-260--storybook-frontpage.netlify.app/docs/8.6/api/csf

   Confirm that the other tab's URL is [`/docs/8.6/api/csf/csf-factories`](https://deploy-preview-260--storybook-frontpage.netlify.app/docs/8.6/api/csf/csf-factories). The actual content there is WIP and not relevant to this PR.

2. And you should not see them on this page:

   https://deploy-preview-260--storybook-frontpage.netlify.app/docs/api/csf