### PR TITLE
Add `noindex` to all non-heading docs index pages

### DIFF
--- a/apps/frontpage/app/docs/[...slug]/page.tsx
+++ b/apps/frontpage/app/docs/[...slug]/page.tsx
@@ -1,5 +1,5 @@
 import { type Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { globalSearchMetaKeys, globalSearchImportance } from '@repo/ui';
 import { type DocsVersion, latestVersion } from '@repo/utils';
 import { getVersion } from '../../../lib/get-version';
@@ -51,13 +51,21 @@ export const generateMetadata: GenerateMetaData = async ({ params }) => {
 
   return {
     title: page?.title ? `${page.title} | Storybook docs` : 'Storybook docs',
-    alternates: {
-      canonical: findPage?.canonical,
-    },
-    other: {
-      [globalSearchMetaKeys.version]: activeVersion.id,
-      [globalSearchMetaKeys.importance]: globalSearchImportance.docs,
-    },
+    ...(page?.isIndexPage && !page?.isHeading
+      ? {
+          robots: {
+            index: false,
+          },
+        }
+      : {
+          alternates: {
+            canonical: findPage?.canonical,
+          },
+          other: {
+            [globalSearchMetaKeys.version]: activeVersion.id,
+            [globalSearchMetaKeys.importance]: globalSearchImportance.docs,
+          },
+        }),
   };
 };
 
@@ -79,14 +87,6 @@ export const generateStaticParams = () => {
 };
 
 export default async function Page({ params: { slug } }: PageProps) {
-  // If the page is an index page, redirect to the parent page
-  const isIndex = slug && slug[slug.length - 1] === 'index';
-  if (isIndex) {
-    const newSlug = slug ?? [];
-    const pathWithoutIndex = `/docs/${newSlug.slice(0, -1).join('/')}`;
-    redirect(pathWithoutIndex);
-  }
-
   const { page } = await getPageFromSlug(slug);
   if (!page) notFound();
 

--- a/apps/frontpage/lib/get-page.tsx
+++ b/apps/frontpage/lib/get-page.tsx
@@ -21,6 +21,7 @@ export interface PageDataProps {
   title?: string;
   hideRendererSelector?: boolean;
   isIndexPage: boolean;
+  isHeading: boolean;
   tabs: RawTreeProps[];
   content: ReactElement;
   path: string;
@@ -47,6 +48,7 @@ export const getPageData = async (
 
   const isIndexMDX = fs.existsSync(indexPathMDX);
   const isIndexMD = fs.existsSync(indexPathMD);
+  const isIndexPage = isIndexMDX || isIndexMD;
   const isLink = linkPath ? fs.existsSync(linkPath) : false;
 
   let newPath = null;
@@ -99,9 +101,9 @@ export const getPageData = async (
     ? `${rootPath}/${pathString}`.split('/').slice(0, -1).join('/')
     : `${rootPath}/${pathString}`;
 
-  const parent = getDocsTreeFromPath(pathToFiles);
+  const children = getDocsTreeFromPath(pathToFiles);
 
-  const sorted = parent.sort((a, b) =>
+  const sorted = children.sort((a, b) =>
     a.tab?.order && b.tab?.order ? a.tab.order - b.tab.order : 0,
   );
 
@@ -109,9 +111,10 @@ export const getPageData = async (
 
   return {
     ...frontmatter,
-    isIndexPage: isIndexMDX || isIndexMD,
+    isIndexPage,
+    isHeading: isIndexPage && path.length < 3,
     path: newPath,
-    tabs: index?.isTab ? parent : [],
+    tabs: index?.isTab ? children : [],
     content,
   };
 };


### PR DESCRIPTION
- Add: `/docs/writing-stories/mocking-data-and-modules`
- Don't add: `/docs/writing-stories`