### PR TITLE
UI: Remove Webpack related frameworks

### DIFF
--- a/apps/frontpage/components/docs/mdx/home-renderers.tsx
+++ b/apps/frontpage/components/docs/mdx/home-renderers.tsx
@@ -53,12 +53,6 @@ export function HomeRenderers({ activeVersion }: HomeRenderersProps) {
         title="Vue"
       />
       <Card
-        href="/docs/get-started/frameworks/vue3-webpack5/?renderer=vue"
-        logo="logo-vue.svg"
-        subtitle="with Webpack"
-        title="Vue"
-      />
-      <Card
         href="/docs/get-started/frameworks/angular/?renderer=angular"
         logo="logo-angular.svg"
         title="Angular"
@@ -75,21 +69,9 @@ export function HomeRenderers({ activeVersion }: HomeRenderersProps) {
         title="Svelte"
       />
       <Card
-        href="/docs/get-started/frameworks/svelte-webpack5/?renderer=svelte"
-        logo="logo-svelte.svg"
-        subtitle="with Webpack"
-        title="Svelte"
-      />
-      <Card
         href="/docs/get-started/frameworks/web-components-vite/?renderer=web-components"
         logo="logo-web-components.svg"
         subtitle="with Vite"
-        title="Web Components"
-      />
-      <Card
-        href="/docs/get-started/frameworks/web-components-webpack5/?renderer=web-components"
-        logo="logo-web-components.svg"
-        subtitle="with Webpack"
         title="Web Components"
       />
     </div>


### PR DESCRIPTION
Follows up on the [#30980](https://github.com/storybookjs/storybook/issues/30980)

With this pull request, the `HomeRenderer` component was updated to remove references to the Webpack-based frameworks.

I left the `Do not merge` and set up `sb-9-changes` labels to avoid accidentally getting this pr merged and released ahead of time.

@kylegach let me know of any feedback you may have and we'll go from there. Thanks in advance