### PR TITLE
Fix: Showcase Nav links

### DIFF
--- a/packages/ui/src/footer/nav.ts
+++ b/packages/ui/src/footer/nav.ts
@@ -30,8 +30,8 @@ export const footerNav = [
   {
     title: 'Showcase',
     links: [
-      { title: 'About', href: '/showcase/about' },
       { title: 'Explore', href: '/showcase' },
+      { title: 'About', href: '/showcase/about' },
     ],
   },
 ];

--- a/packages/ui/src/footer/nav.ts
+++ b/packages/ui/src/footer/nav.ts
@@ -30,9 +30,8 @@ export const footerNav = [
   {
     title: 'Showcase',
     links: [
+      { title: 'About', href: '/showcase/about' },
       { title: 'Explore', href: '/showcase' },
-      { title: 'Projects', href: '/showcase/projects' },
-      { title: 'Component glossary', href: '/showcase/glossary' },
     ],
   },
 ];


### PR DESCRIPTION
With this pull request, the Showcase links referenced in the Footer were updated to prevent them from 404ing as part of a recent restructure. Additionally, the other links were adjusted to avoid opening the same page (i.e., the "Explore" and "Projects" links are opening the same page)

What was done:
- Adjusted the Showcase links to reflect the current pages
- Removed the "Glossary" link to prevent it from 404ing