### PR TITLE
Add telemetry route to direct errors to sentry

### DIFF
--- a/apps/frontpage/app/event-log/route.ts
+++ b/apps/frontpage/app/event-log/route.ts
@@ -92,12 +92,8 @@ export async function POST(request: NextRequest) {
         headers: { 'Content-Type': 'application/x-sentry-envelope' },
         body: envelope,
       });
-
-      // eslint-disable-next-line no-console -- we want to log the error
-      console.error('Failed to send event to Sentry', res);
     } catch (e) {
-      // eslint-disable-next-line no-console -- we want to log the error
-      console.error('Error to send event to Sentry', e);
+      //
     }
   }
 

--- a/apps/frontpage/app/event-log/route.ts
+++ b/apps/frontpage/app/event-log/route.ts
@@ -46,6 +46,7 @@ export async function POST(request: NextRequest) {
       userSince: string;
     };
     payload: { error: { message: string }; errorHash: string; name: string };
+    metadata: { userSince: string };
   } = JSON.parse(body);
 
   if (received.eventType === 'error') {
@@ -63,7 +64,7 @@ export async function POST(request: NextRequest) {
       const payload = {
         event_id: eventId,
         release: received?.context?.storybookVersion ?? 'unknown',
-        user: { id: received?.context?.userSince?.toString() ?? 'unknown' },
+        user: { id: received?.metadata?.userSince?.toString() ?? 'unknown' },
         timestamp: now,
         environment:
           getEnvironment(received?.context?.storybookVersion) ?? 'unknown',

--- a/apps/frontpage/app/event-log/route.ts
+++ b/apps/frontpage/app/event-log/route.ts
@@ -87,7 +87,7 @@ export async function POST(request: NextRequest) {
         JSON.stringify(payload),
       ].join('\n');
 
-      const res = await fetch(sentryEnvelopeUrl, {
+      await fetch(sentryEnvelopeUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-sentry-envelope' },
         body: envelope,

--- a/apps/frontpage/app/event-log/route.ts
+++ b/apps/frontpage/app/event-log/route.ts
@@ -93,7 +93,8 @@ export async function POST(request: NextRequest) {
         body: envelope,
       });
     } catch (e) {
-      //
+      // eslint-disable-next-line no-console -- we want to log the error
+      console.error('Failed to send event to Sentry', e);
     }
   }
 

--- a/apps/frontpage/app/event-log/route.ts
+++ b/apps/frontpage/app/event-log/route.ts
@@ -62,17 +62,18 @@ export async function POST(request: NextRequest) {
       const itemHeader = { type: 'event' };
       const payload = {
         event_id: eventId,
-        release: received.context.storybookVersion,
-        user: { id: received.context.userSince.toString() },
+        release: received?.context?.storybookVersion ?? 'unknown',
+        user: { id: received?.context?.userSince.toString() ?? 'unknown' },
         timestamp: now,
-        environment: getEnvironment(received.context.storybookVersion),
+        environment:
+          getEnvironment(received?.context?.storybookVersion) ?? 'unknown',
         level: 'error',
         platform: 'javascript',
-        tags: flatten(received),
+        tags: flatten(received ?? {}),
         message: {
           formatted:
-            received.payload.error.message ||
-            received.payload.errorHash ||
+            received?.payload?.error?.message ||
+            received?.payload?.errorHash ||
             'Unknown error',
         },
       };

--- a/apps/frontpage/app/event-log/route.ts
+++ b/apps/frontpage/app/event-log/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
       anonymousId: string;
       userSince: string;
     };
-    payload: { error: { message: string }; errorHash: string };
+    payload: { error: { message: string }; errorHash: string; name: string };
   } = JSON.parse(body);
 
   if (received.eventType === 'error') {
@@ -71,8 +71,10 @@ export async function POST(request: NextRequest) {
         platform: 'javascript',
         tags: flatten(received ?? {}),
         message: {
+          message: received?.payload?.name || 'Uncategorized error',
           formatted:
             received?.payload?.error?.message ||
+            received?.payload?.name ||
             received?.payload?.errorHash ||
             'Unknown error',
         },

--- a/apps/frontpage/app/event-log/route.ts
+++ b/apps/frontpage/app/event-log/route.ts
@@ -84,13 +84,17 @@ export async function POST(request: NextRequest) {
         JSON.stringify(payload),
       ].join('\n');
 
-      await fetch(sentryEnvelopeUrl, {
+      const res = await fetch(sentryEnvelopeUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-sentry-envelope' },
         body: envelope,
       });
+
+      // eslint-disable-next-line no-console -- we want to log the error
+      console.error('Failed to send event to Sentry', res);
     } catch (e) {
-      //
+      // eslint-disable-next-line no-console -- we want to log the error
+      console.error('Error to send event to Sentry', e);
     }
   }
 

--- a/apps/frontpage/app/event-log/route.ts
+++ b/apps/frontpage/app/event-log/route.ts
@@ -63,7 +63,7 @@ export async function POST(request: NextRequest) {
       const payload = {
         event_id: eventId,
         release: received?.context?.storybookVersion ?? 'unknown',
-        user: { id: received?.context?.userSince.toString() ?? 'unknown' },
+        user: { id: received?.context?.userSince?.toString() ?? 'unknown' },
         timestamp: now,
         environment:
           getEnvironment(received?.context?.storybookVersion) ?? 'unknown',

--- a/apps/frontpage/app/event-log2/route.ts
+++ b/apps/frontpage/app/event-log2/route.ts
@@ -30,7 +30,11 @@ function flatten(
 export async function POST(request: NextRequest) {
   const { headers, method } = request;
   const body = await request.text();
-  const received = JSON.parse(body);
+  const received: {
+    eventType: string;
+    context: { storybookVersion: string; anonymousId: string };
+    payload: { error: { message: string }; errorHash: string };
+  } = JSON.parse(body);
 
   if (received.eventType === 'error') {
     const now = new Date().toISOString();
@@ -54,7 +58,7 @@ export async function POST(request: NextRequest) {
       message: {
         formatted:
           received.payload.error.message ||
-          received.errorHash ||
+          received.payload.errorHash ||
           'Unknown error',
       },
     };

--- a/apps/frontpage/app/event-log2/route.ts
+++ b/apps/frontpage/app/event-log2/route.ts
@@ -1,4 +1,3 @@
-import { headers } from 'next/headers';
 import type { NextRequest } from 'next/server';
 import crypto from 'node:crypto';
 

--- a/apps/frontpage/app/event-log2/route.ts
+++ b/apps/frontpage/app/event-log2/route.ts
@@ -1,7 +1,7 @@
-import type { NextRequest } from 'next/server';
 import crypto from 'node:crypto';
+import type { NextRequest } from 'next/server';
 
-const sentryEnvelopeUrl = `https://o4507096816484352.ingest.sentry.io/api/4507096819892224/envelope/?sentry_key=${process.env.SENTRY_KEY}&sentry_version=7`;
+const sentryEnvelopeUrl = `https://o4507096816484352.ingest.sentry.io/api/4507096819892224/envelope/?sentry_key=${process.env.SENTRY_KEY ?? ''}&sentry_version=7`;
 
 function flatten(
   obj: Record<string, unknown>,
@@ -78,15 +78,11 @@ export async function POST(request: NextRequest) {
       JSON.stringify(payload),
     ].join('\n');
 
-    const res = await fetch(sentryEnvelopeUrl, {
+    await fetch(sentryEnvelopeUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-sentry-envelope' },
       body: envelope,
     });
-
-    if (!res.ok) {
-      console.error('Failed to send event to Sentry', res);
-    }
   }
 
   // we send the request forward to https://us-central1-storybook-warehouse.cloudfunctions.net/storybook-event-log-production-event-log

--- a/apps/frontpage/app/event-log2/route.ts
+++ b/apps/frontpage/app/event-log2/route.ts
@@ -1,0 +1,93 @@
+import { headers } from 'next/headers';
+import type { NextRequest } from 'next/server';
+import crypto from 'node:crypto';
+
+const sentryEnvelopeUrl = `https://o4507096816484352.ingest.sentry.io/api/4507096819892224/envelope/?sentry_key=${process.env.SENTRY_KEY}&sentry_version=7`;
+
+function flatten(
+  obj: Record<string, unknown>,
+  acc: Record<string, unknown> = {},
+  prefix = '',
+) {
+  Object.entries(obj).forEach(([key, value]) => {
+    const p = (prefix ? `${prefix}.${key}` : key)
+      .replaceAll('@', 'at_')
+      .replaceAll('/', 'slash_');
+    if (typeof value === 'object' && value !== null) {
+      try {
+        flatten(value as Record<string, unknown>, acc, p);
+      } catch (e) {
+        //
+      }
+    } else if (typeof value === 'string' && value.includes('\n')) {
+      acc[p] = `...${value.split('\n')[0]}...`;
+    } else if (value) {
+      acc[p] = value;
+    }
+  });
+  return acc;
+}
+
+export async function POST(request: NextRequest) {
+  const { headers, method } = request;
+  const body = await request.text();
+  const received = JSON.parse(body);
+
+  if (received.eventType === 'error') {
+    const now = new Date().toISOString();
+    const eventId = crypto.randomUUID().replace(/-/g, '');
+
+    const envelopeHeader = {
+      event_id: eventId,
+      sent_at: now,
+      sdk: { name: 'custom.fetch.sender', version: '1.0' },
+    };
+
+    const itemHeader = { type: 'event' };
+    const payload = {
+      event_id: eventId,
+      release: received.context.storybookVersion,
+      user: { id: received.context.anonymousId },
+      timestamp: now,
+      level: 'error',
+      platform: 'javascript',
+      tags: flatten(received),
+      message: {
+        formatted:
+          received.payload.error.message ||
+          received.errorHash ||
+          'Unknown error',
+      },
+    };
+
+    const envelope = [
+      JSON.stringify(envelopeHeader),
+      JSON.stringify(itemHeader),
+      JSON.stringify(payload),
+    ].join('\n');
+
+    const res = await fetch(sentryEnvelopeUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-sentry-envelope' },
+      body: envelope,
+    });
+
+    if (!res.ok) {
+      console.error('Failed to send event to Sentry', res);
+    }
+  }
+
+  // we send the request forward to https://us-central1-storybook-warehouse.cloudfunctions.net/storybook-event-log-production-event-log
+  const res = await fetch(
+    'https://us-central1-storybook-warehouse.cloudfunctions.net/storybook-event-log-production-event-log',
+    {
+      method,
+      body,
+      headers,
+    },
+  );
+
+  return new Response(await res.text(), {
+    status: res.status,
+  });
+}

--- a/apps/frontpage/app/event-log2/route.ts
+++ b/apps/frontpage/app/event-log2/route.ts
@@ -27,6 +27,14 @@ function flatten(
   return acc;
 }
 
+function getEnvironment(storybookVersion: string) {
+  if (storybookVersion.includes('alpha')) return 'alpha';
+  if (storybookVersion.includes('beta')) return 'beta';
+  if (storybookVersion.includes('rc')) return 'rc';
+  if (storybookVersion.includes('canary')) return 'canary';
+  return 'latest';
+}
+
 export async function POST(request: NextRequest) {
   const { headers, method } = request;
   const body = await request.text();
@@ -52,6 +60,7 @@ export async function POST(request: NextRequest) {
       release: received.context.storybookVersion,
       user: { id: received.context.anonymousId },
       timestamp: now,
+      environment: getEnvironment(received.context.storybookVersion),
       level: 'error',
       platform: 'javascript',
       tags: flatten(received),

--- a/apps/frontpage/components/community.tsx
+++ b/apps/frontpage/components/community.tsx
@@ -98,9 +98,10 @@ export function Community() {
 
   useEffect(() => {
     const pauseVideo = () => {
-      videoBRef.current && videoBRef.current.pause();
-      videoBRef.current &&
+      if (videoBRef.current) {
+        videoBRef.current.pause();
         videoBRef.current.removeEventListener('loadeddata', pauseVideo);
+      }
     };
 
     if (videoBRef.current && !pauseVideoB) {
@@ -111,14 +112,14 @@ export function Community() {
 
   return (
     <div
-      className="grid grid-cols-[repeat(4,_1fr)] auto-rows-[280px] gap-8"
+      className="grid auto-rows-[280px] grid-cols-[repeat(4,_1fr)] gap-8"
       ref={sectionRef}
     >
       <div className="relative col-[1_/_-1] rounded-lg bg-zinc-600 sm:col-[1_/_3]">
         <AnimatePresence initial={false}>
           <motion.div
             animate="center"
-            className="absolute top-0 bottom-0 left-0 right-0 bg-center bg-no-repeat bg-cover rounded-lg"
+            className="absolute bottom-0 left-0 right-0 top-0 rounded-lg bg-cover bg-center bg-no-repeat"
             exit="exit"
             initial="enter"
             key={activeIndex.img}
@@ -140,7 +141,7 @@ export function Community() {
           <motion.video
             animate="center"
             autoPlay
-            className="absolute top-0 bottom-0 left-0 right-0 object-cover w-full h-full overflow-hidden rounded-lg"
+            className="absolute bottom-0 left-0 right-0 top-0 h-full w-full overflow-hidden rounded-lg object-cover"
             exit="exit"
             initial="enter"
             key={activeIndex.videoA}
@@ -164,7 +165,7 @@ export function Community() {
           <motion.video
             animate="center"
             autoPlay
-            className="absolute top-0 bottom-0 left-0 right-0 object-cover w-full h-full overflow-hidden rounded-lg"
+            className="absolute bottom-0 left-0 right-0 top-0 h-full w-full overflow-hidden rounded-lg object-cover"
             exit="exit"
             initial="enter"
             key={activeIndex.videoB}

--- a/apps/frontpage/public/netlify.toml
+++ b/apps/frontpage/public/netlify.toml
@@ -49,11 +49,6 @@
   status = 200
 
 [[redirects]]
-  from = "/event-log"
-  to = "https://us-central1-storybook-warehouse.cloudfunctions.net/storybook-event-log-production-event-log"
-  status = 200
-
-[[redirects]]
   from = "/whats-new/v1/*"
   to = "https://storybook-dx.netlify.app/.netlify/functions/whats-new/:splat"
   status = 200

--- a/apps/frontpage/tsconfig.json
+++ b/apps/frontpage/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
   "compilerOptions": {
-    "plugins": [{ "name": "next" }]
+    "plugins": [{ "name": "next" }],
+    "lib": ["ES2022"]
   },
   "include": [
     "next-env.d.ts",

--- a/apps/frontpage/tsconfig.json
+++ b/apps/frontpage/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@repo/typescript-config/nextjs.json",
   "compilerOptions": {
     "plugins": [{ "name": "next" }],
-    "lib": ["ES2022"]
+    "lib": ["ES2022", "dom"]
   },
   "include": [
     "next-env.d.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,7 @@
   "globalEnv": [
     "ALGOLIA_API_KEY",
     "ANALYZE",
+    "SENTRY_KEY",
     "CONTEXT",
     "GCP_CREDENTIALS",
     "GITHUB_STORYBOOK_BOT_PAT",


### PR DESCRIPTION
Add replaced the previous redirect rule with a server function.

This intercepts the telemetry data getting reported and reports to sentry if the eventType is an Error.
It then maps the telemetry data to Sentry's data-model and submits.

Then the whole telemetry data is send as-before to where we proxied it to before.