### PR TITLE
menu(fix): close mobile docs menu after navigation

### DIFF
--- a/apps/frontpage/components/docs/submenu.tsx
+++ b/apps/frontpage/components/docs/submenu.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { FC } from 'react';
+import { useEffect, useState, type FC } from 'react';
 import { ChevronSmallRightIcon, MenuIcon } from '@storybook/icons';
 import { usePathname, useSelectedLayoutSegment } from 'next/navigation';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
@@ -33,9 +33,18 @@ export const Submenu: FC<SubmenuProps> = ({ listOfTrees }) => {
     title = activeSection.title;
   }
 
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  useEffect(() => {
+    setIsMenuOpen(false);
+  }, [pathname]);
+
   return (
     <div className="flex items-center gap-3 p-4 text-sm border-b border-zinc-200 sm:px-8 md:hidden dark:border-slate-800">
-      <DropdownMenu.Root>
+      <DropdownMenu.Root
+        onOpenChange={setIsMenuOpen}
+        open={isMenuOpen}
+      >
         <DropdownMenu.Trigger asChild>
           <button
             className={cn(


### PR DESCRIPTION
## Summary
This PR for the [documentation site](https://storybook.js.org/docs) fixes a bug (or non-standard menu modal behavior) on mobile viewports where pressing a link and loading a new page doesn't dismiss the submenu modal and requires it to be manually closed by the user each time to reveal the new page. The fix closes the modal after page navigation without other side effects.

**🔗 Live Demo:** [storybook-docs.ritovision.com](https://storybook-docs.ritovision.com/)

## Bug Breakdown

**Expectation:** 
On mobile viewports (sidebar hidden), opening the docs submenu modal, tapping any doc link, and navigating to that page should dismiss the modal automatically, mirroring the desktop sidebar’s “select → view content” flow and standard web expectations for menu modal behavior.

[storybook-fix.webm](https://github.com/user-attachments/assets/95031f49-30ec-4f82-b570-ccbb3cfab702)

*Using Chrome browser on desktop to demonstrate with the mouse cursor present, expect the same modal behavior on actual mobile browsers.*

**Reality:** 
Tapping a link triggers navigation in the background but leaves the Radix modal open, forcing users to manually close it with the hamburger icon before revealing the new page. Since the modal covers the screen when opened (the full page height on smaller mobile devices), it prevents users from even clearly seeing that the page has changed in the background, 

[storybook-bug.webm](https://github.com/user-attachments/assets/2315ccaf-533e-4981-8894-310d286b1232)

<img width="540" height="1037" alt="storybook-modal" src="https://github.com/user-attachments/assets/d4421986-2def-4b72-9488-695e2ba1cbf5" />

*Here is an actual mobile device screen rendering the modal in Chrome mobile to demonstrate it covering the entire page background.*

**Reproducibility:**
 (1a) On desktop browser, resize to below md viewport (sidebar should disappear), or 
 (1b) Use a mobile device
 (2) Navigate to [storybook.js.org/docs](https://storybook.js.org/docs)
 (3) Tap the hamburger in the docs subheader on the upper left (not the main menu hamburger icon in the upper right) to open the modal (sub)menu
 (4). Select any item inside the modal menu that should open a new page. After the route updates, observe the modal overlay still covering the screen
(5) Tap the hamburger icon again to close the overlay and reveal the new page

## Solution
Control the submenu’s open state and close it whenever the Next pathname changes in `submenu.tsx` . This targets only the mobile modal navigation; the desktop sidebar `sidebar.tsx` remains untouched, so there are no side effects for desktop viewports.

The solution can be tested in the live [demo link](https://storybook-docs.ritovision.com/).