### PR TITLE
Fix: Correct aria-label for Discord social link

### DIFF
--- a/packages/ui/src/footer/top-section.tsx
+++ b/packages/ui/src/footer/top-section.tsx
@@ -45,7 +45,7 @@ export function TopSection({ variant }: TopSectionProps): JSX.Element {
           <Circle
             href="https://discord.gg/storybook"
             variant={variant}
-            name="Storybook"
+            name="Discord"
           >
             <DiscordIcon size={18} />
           </Circle>


### PR DESCRIPTION
## Summary
Fixes the accessibility issue where the Discord social media link in the footer was incorrectly labeled as "Storybook" instead of "Discord".

## Solved Issue
Close #374

<img width="1875" height="919" alt="image" src="https://github.com/user-attachments/assets/71fc93d0-22b3-4571-ba8b-46ed33ad4ca2" />

The Discord icon link had a misleading aria-label attribute that would cause screen reader users to hear "Storybook" when the link actually points to Discord. This created confusion and violated WCAG 2.1 accessibility standards.

As shown in screenshot, all other social media links (GitHub, BlueSky, Twitter, YouTube) have correct aria-label values matching their respective platforms. Only the Discord link has this mismatch.


## Solution
Changed the name prop of the Circle component from "Storybook" to "Discord" to ensure the accessible label matches the visual icon and link destination.
