### PR TITLE
SSG all tag pages instead of categories only

### DIFF
--- a/apps/addon-catalog/app/(home)/tag/[...name]/page.tsx
+++ b/apps/addon-catalog/app/(home)/tag/[...name]/page.tsx
@@ -34,6 +34,11 @@ const getCachedTagFromName = unstable_cache(
   ['tag-details'],
 );
 
+const getCachedTags = unstable_cache(
+  async () => fetchTagsData(),
+  ['tags'],
+);
+
 const getCachedCategoryTags = unstable_cache(
   async () => fetchTagsData({ isCategory: true }),
   ['category-tags'],
@@ -89,7 +94,7 @@ export default async function TagDetails({
 }
 
 export async function generateStaticParams() {
-  const tags = (await getCachedCategoryTags()) || [];
+  const tags = (await getCachedTags()) || [];
   const listOfNames = tags.map((tag) => ({ name: [...tag.split('/')] }));
 
   if (listOfNames.length === 0) {

--- a/apps/addon-catalog/app/(home)/tag/[...name]/page.tsx
+++ b/apps/addon-catalog/app/(home)/tag/[...name]/page.tsx
@@ -19,7 +19,7 @@ type GenerateMetaData = (props: {
 }) => Promise<Metadata>;
 
 interface TagDetailsProps {
-  params: Params;
+  params: Promise<Params>;
 }
 
 async function getTagFromName(
@@ -68,8 +68,9 @@ export const generateMetadata: GenerateMetaData = async ({ params }) => {
 };
 
 export default async function TagDetails({
-  params: { name },
+  params,
 }: TagDetailsProps) {
+  const { name } = await params;
   const data = await getCachedTagFromName(name);
 
   if (!data || 'error' in data) return notFound();

--- a/apps/addon-catalog/app/[...addonName]/page.tsx
+++ b/apps/addon-catalog/app/[...addonName]/page.tsx
@@ -23,7 +23,7 @@ type GenerateMetaData = (props: {
 }) => Promise<Metadata>;
 
 interface AddonDetailsProps {
-  params: Params;
+  params: Promise<Params>;
 }
 
 async function getAddonFromName(
@@ -55,7 +55,8 @@ export const generateMetadata: GenerateMetaData = async ({ params }) => {
 };
 
 export default async function AddonDetails({ params }: AddonDetailsProps) {
-  const addon = await getAddonFromName(params.addonName);
+  const { addonName } = await params;
+  const addon = await getAddonFromName(addonName);
 
   if (!addon) notFound();
 

--- a/apps/addon-catalog/next.config.mjs
+++ b/apps/addon-catalog/next.config.mjs
@@ -38,7 +38,7 @@ const nextConfig = withPlausibleProxy({
   // more robust static generation with retries and concurrency control
   experimental: {
     staticGenerationRetryCount: 1,
-    staticGenerationMaxConcurrency: 50,
+    staticGenerationMaxConcurrency: 10,
   },
 });
 

--- a/apps/addon-catalog/next.config.mjs
+++ b/apps/addon-catalog/next.config.mjs
@@ -35,6 +35,11 @@ const nextConfig = withPlausibleProxy({
       },
     ];
   },
+  // more robust static generation with retries and concurrency control
+  experimental: {
+    staticGenerationRetryCount: 1,
+    staticGenerationMaxConcurrency: 50,
+  },
 });
 
 export default nextConfig;

--- a/apps/addon-catalog/next.config.mjs
+++ b/apps/addon-catalog/next.config.mjs
@@ -1,7 +1,9 @@
 /** @type {import('next').NextConfig} */
 import { withPlausibleProxy } from 'next-plausible';
 
-const nextConfig = withPlausibleProxy()({
+const nextConfig = withPlausibleProxy({
+  src: 'https://plausible.io/js/pa-anM74fP8S5w3vipeaMMrx.js',
+})({
   basePath: '/addons',
   images: {
     unoptimized: true,

--- a/apps/frontpage/next.config.js
+++ b/apps/frontpage/next.config.js
@@ -125,7 +125,7 @@ module.exports = withBundleAnalyzer(
     // more robust static generation with retries and concurrency control
     experimental: {
       staticGenerationRetryCount: 1,
-      staticGenerationMaxConcurrency: 50,
+      staticGenerationMaxConcurrency: 10,
     },
   }),
 );


### PR DESCRIPTION
## Summary

- SSG all tag pages instead of categories only

## Notes

Cherry-picked from #398 (by @kylegach), rebased on top of the Next.js 15 upgrade (#410).

## Test plan

- [ ] Verify tag pages are statically generated at build time
- [ ] Confirm no regressions on category pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)