### PR TITLE
Fix copy markdown and .md routes for /docs root page

### DIFF
--- a/apps/frontpage/components/docs/copy-markdown-button.tsx
+++ b/apps/frontpage/components/docs/copy-markdown-button.tsx
@@ -2,6 +2,7 @@
 
 import { type FC, useCallback, useState } from 'react';
 import { usePathname } from 'next/navigation';
+import { latestVersion } from '@repo/utils';
 import { useDocs } from '../../app/docs/provider';
 import { Button } from './button';
 
@@ -11,7 +12,10 @@ export const CopyMarkdownButton: FC = () => {
   const [copied, setCopied] = useState(false);
 
   const handleClick = useCallback(() => {
-    const mdApiPath = pathname.replace(/^\/docs\//, '/md-api/');
+    const mdApiPath =
+      /^\/docs\/?$/.test(pathname)
+        ? `/md-api/${latestVersion.id}`
+        : pathname.replace(/^\/docs\//, '/md-api/');
     const params = new URLSearchParams();
     if (activeRenderer) params.set('renderer', activeRenderer);
     if (activeLanguage) params.set('language', activeLanguage);

--- a/apps/frontpage/middleware.ts
+++ b/apps/frontpage/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { docsVersions } from '@repo/utils';
+import { docsVersions, latestVersion } from '@repo/utils';
 
 /**
  * Extract version prefix and remaining doc path from a docs URL path.
@@ -58,14 +58,13 @@ export async function middleware(request: NextRequest) {
 
   // .md suffix: serve markdown for any /docs/*.md URL (like Stripe's docs.stripe.com/testing.md)
   // Supports versioned URLs: /docs/9/writing-stories.md, /docs/8/get-started.md
-  if (pathname.startsWith('/docs/') && pathname.endsWith('.md')) {
-    const rawPath = pathname.replace(/^\/docs\//, '').replace(/\.md$/, '');
+  // Also supports /docs.md for the root docs page
+  if (pathname.startsWith('/docs') && pathname.endsWith('.md')) {
+    const rawPath = pathname.replace(/^\/docs\/?/, '').replace(/\.md$/, '');
     const { versionSlug, docPath } = extractVersionAndPath(rawPath);
 
-    if (docPath) {
-      const url = buildMdRewriteUrl(request, docPath, versionSlug);
-      return NextResponse.rewrite(url);
-    }
+    const url = buildMdRewriteUrl(request, docPath, versionSlug ?? latestVersion.id);
+    return NextResponse.rewrite(url);
   }
 
   // Content negotiation: serve markdown for docs pages when requested by LLMs
@@ -77,13 +76,10 @@ export async function middleware(request: NextRequest) {
 
   if (prefersMarkdown && pathname.startsWith('/docs') && !pathname.endsWith('.md')) {
     const rawPath = pathname.replace(/^\/docs\/?/, '');
-    if (rawPath) {
-      const { versionSlug, docPath } = extractVersionAndPath(rawPath);
-      if (docPath) {
-        const url = buildMdRewriteUrl(request, docPath, versionSlug);
-        return NextResponse.rewrite(url);
-      }
-    }
+    const { versionSlug, docPath } = extractVersionAndPath(rawPath);
+
+    const url = buildMdRewriteUrl(request, docPath, versionSlug ?? latestVersion.id);
+    return NextResponse.rewrite(url);
   }
 
   return NextResponse.next();


### PR DESCRIPTION
The copy markdown button and middleware .md/.content-negotiation handlers all failed on the /docs root route because they assumed a slug was always present. Now they fall back to latestVersion.id when the path is /docs or /docs/.